### PR TITLE
Update for new do-agent repo and remove old one

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,11 +11,18 @@ galaxy_info:
         - wily
         - xenial
         - yakkety
+        - xenial
+        - zesty
+        - artful
+        - bionic
+        - cosmic
     - name: Debian
       versions:
         - jessie
+        - stretch
     - name: EL
       versions:
+        - 6
         - 7
   galaxy_tags:
     - cloud

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,14 @@
     state: present
   when: agent_apt_key_url is defined
 
+- name: ensure old do-agent apt repository is removed
+  apt_repository:
+    repo: "{{ agent_apt_repo_old }}"
+    filename: "{{ agent_apt_repo_file }}"
+    update_cache: true
+    state: absent
+  when: agent_apt_repo_old is defined
+
 - name: ensure do-agent apt repository is enabled
   apt_repository:
     repo: "{{ agent_apt_repo }}"
@@ -28,6 +36,19 @@
     update_cache: true
     state: present
   when: agent_apt_repo is defined
+
+- name: ensure old do-agent yum repository is removed
+  yum_repository:
+    name: digitalocean-agent
+    description: DigitalOcean agent
+    baseurl: "{{ agent_yum_repo_old }}"
+    file: "{{ agent_yum_repo_file }}"
+    gpgkey: "{{ agent_yum_key_url }}"
+    gpgcheck: yes
+    enabled: yes
+    failovermethod: priority
+    state: absent
+  when: agent_yum_repo_old is defined
 
 - name: ensure do-agent yum repository is enabled
   yum_repository:
@@ -37,12 +58,18 @@
     file: "{{ agent_yum_repo_file }}"
     gpgkey: "{{ agent_yum_key_url }}"
     gpgcheck: yes
-    state: present
     enabled: yes
     failovermethod: priority
+    state: present
   when: agent_yum_repo is defined
 
-- name: ensure do-agent packages are installed
+- name: ensure old do-agent packages are uninstalled with yum
+  package:
+    name: do-agent-0.*
+    state: absent
+  when: agent_yum_repo_old is defined
+
+- name: ensure latest do-agent packages are installed
   package:
     name: do-agent
     state: latest

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -5,6 +5,8 @@ agent_pre_packages:
 
 agent_apt_key_url: https://repos.insights.digitalocean.com/sonar-agent.asc
 
+agent_apt_repo_old: deb https://repos.sonar.digitalocean.com/apt main main
+
 agent_apt_repo: deb https://repos.insights.digitalocean.com/apt/do-agent main main
 
 agent_apt_repo_file: digitalocean-agent

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -3,8 +3,8 @@ agent_pre_packages:
   - apt-transport-https
   - ca-certificates
 
-agent_apt_key_url: https://repos.sonar.digitalocean.com/sonar-agent.asc
+agent_apt_key_url: https://repos.insights.digitalocean.com/sonar-agent.asc
 
-agent_apt_repo: deb https://repos.sonar.digitalocean.com/apt main main
+agent_apt_repo: deb https://repos.insights.digitalocean.com/apt/do-agent main main
 
-agent_apt_repo_file: digitalocean-agent.list
+agent_apt_repo_file: digitalocean-agent

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,4 +1,4 @@
 ---
-agent_yum_key_url: https://repos.sonar.digitalocean.com/sonar-agent.asc
-agent_yum_repo: https://repos.sonar.digitalocean.com/yum/$basearch
+agent_yum_key_url: https://repos.insights.digitalocean.com/sonar-agent.asc
+agent_yum_repo: https://repos.insights.digitalocean.com/yum/do-agent/$basearch
 agent_yum_repo_file: digitalocean-agent

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,4 +1,5 @@
 ---
 agent_yum_key_url: https://repos.insights.digitalocean.com/sonar-agent.asc
 agent_yum_repo: https://repos.insights.digitalocean.com/yum/do-agent/$basearch
+agent_yum_repo_old: https://repos.sonar.digitalocean.com/yum/$basearch
 agent_yum_repo_file: digitalocean-agent


### PR DESCRIPTION
https://www.digitalocean.com/docs/monitoring/how-to/upgrade-legacy-agent/

Note, Fedora is not marked as supported to to this bug in Ansible's DNF support: https://github.com/ansible/ansible/pull/45357