### PR TITLE
Ensure gnupg is installed on debian

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,6 +2,7 @@
 agent_pre_packages:
   - apt-transport-https
   - ca-certificates
+  - gnupg
 
 agent_apt_key_url: https://repos.insights.digitalocean.com/sonar-agent.asc
 


### PR DESCRIPTION
This ensures gnupg is installed to fix the problem described below.

Using this role on Debian 10.2, I encountered this error:

```
TASK [andrewsomething.do-agent : ensure do-agent apt repository public key is installed] ***********************************************************************************************************************************************
fatal: [134.209.111.38]: FAILED! => {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
```

This error replicated in the host's shell:

```sh
$ apt-key add https://repos.insights.digitalocean.com/sonar-agent.asc
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
```